### PR TITLE
feat(typo3): remove htaccess from shared files in default config

### DIFF
--- a/deployer/typo3/config/set.php
+++ b/deployer/typo3/config/set.php
@@ -19,7 +19,6 @@ set('shared_dirs', [
 ]);
 
 set('shared_files', [
-    '{{web_path}}/.htaccess',
     '.env'
 ]);
 


### PR DESCRIPTION
I don't think that this is necessary, because we normally have a versioned htaccess file inside our projects. 