### PR TITLE
fix: define own rsync typo3 settings

### DIFF
--- a/deployer/rsync/config/set.php
+++ b/deployer/rsync/config/set.php
@@ -9,12 +9,27 @@ set('default_timeout', 900);
 
 set('rsync-exclude-file', '.deployment/rsync/exclude.txt');
 
+set('rsync_default_excludes', [
+    '.Build',
+    '.git',
+    '.gitlab',
+    '.ddev',
+    '.deployer',
+    '.idea',
+    '.DS_Store',
+    '.gitlab-ci.yml',
+    '.npm',
+    'package.json',
+    'package-lock.json',
+    'node_modules/'
+]);
+
 /**
  * rsync
  */
 set('rsync_src', './{{app_path}}');
 set('rsync', [
-    'exclude' => [],
+    'exclude' => array_merge(get('shared_dirs'), get('shared_files'), get('rsync_default_excludes')),
     'exclude-file' => get('rsync-exclude-file'),
     'include' => [],
     'include-file' => false,

--- a/deployer/rsync/config/set.php
+++ b/deployer/rsync/config/set.php
@@ -7,13 +7,15 @@ require 'contrib/rsync.php';
 set('repository', '');
 set('default_timeout', 900);
 
+set('rsync-exclude-file', '.deployment/rsync/exclude.txt');
+
 /**
  * rsync
  */
 set('rsync_src', './{{app_path}}');
 set('rsync', [
     'exclude' => [],
-    'exclude-file' => '.deployment/rsync/exclude.txt',
+    'exclude-file' => get('rsync-exclude-file'),
     'include' => [],
     'include-file' => false,
     'filter' => [],

--- a/deployer/typo3/config/set.php
+++ b/deployer/typo3/config/set.php
@@ -54,4 +54,38 @@ set('buffer_config', function () {
     ];
 });
 
+/**
+ * Rsync settings
+ */
+$defaultExcludes = [
+    '.Build',
+    '.git',
+    '.gitlab',
+    '.ddev',
+    '.deployer',
+    '.idea',
+    '.DS_Store',
+    '.gitlab-ci.yml',
+    '.npm',
+    'package.json',
+    'package-lock.json',
+    'node_modules/',
+    'var/',
+    'public/fileadmin/',
+    'public/typo3temp/',
+];
+
+set('rsync', [
+    'exclude' => array_merge(get('shared_dirs'), get('shared_files'), $defaultExcludes),
+    'exclude-file' => get('rsync-exclude-file'),
+    'include' => ['vendor'],
+    'include-file' => false,
+    'filter' => ['dir-merge,-n /.gitignore'],
+    'filter-file' => false,
+    'filter-perdir' => false,
+    'flags' => 'avz',
+    'options' => ['delete', 'keep-dirlinks', 'links'],
+    'timeout' => 600
+]);
+
 set('feature_index_app_type', 'typo3');

--- a/deployer/typo3/config/set.php
+++ b/deployer/typo3/config/set.php
@@ -57,7 +57,7 @@ set('buffer_config', function () {
 /**
  * Rsync settings
  */
-$defaultExcludes = [
+set('rsync_default_excludes', [
     '.Build',
     '.git',
     '.gitlab',
@@ -73,10 +73,10 @@ $defaultExcludes = [
     'var/',
     'public/fileadmin/',
     'public/typo3temp/',
-];
+]);
 
 set('rsync', [
-    'exclude' => array_merge(get('shared_dirs'), get('shared_files'), $defaultExcludes),
+    'exclude' => array_merge(get('shared_dirs'), get('shared_files'), get('rsync_default_excludes')),
     'exclude-file' => get('rsync-exclude-file'),
     'include' => ['vendor'],
     'include-file' => false,


### PR DESCRIPTION
According to the newest deployer version 7.3.2, there is a new default setting for TYPO3 rsync excludes (https://github.com/deployphp/deployer/blob/master/recipe/typo3.php#L61) which causes some errors with our deployment concept. So we need to adjust them to our own needs. 