### PR TITLE
feat: set default keep releases to 2 for typo3/drupal deployment

### DIFF
--- a/deployer/drupal/config/set.php
+++ b/deployer/drupal/config/set.php
@@ -5,6 +5,7 @@ namespace Deployer;
 require 'recipe/drupal8.php';
 
 set('default_timeout', 900);
+set('keep_releases', 2);
 
 set('web_path', 'web/');
 set('drupal_site', 'default');

--- a/deployer/typo3/config/set.php
+++ b/deployer/typo3/config/set.php
@@ -4,6 +4,9 @@ namespace Deployer;
 
 require 'recipe/typo3.php';
 
+set('default_timeout', 900);
+set('keep_releases', 2);
+
 // TYPO3
 set('web_path', 'public/');
 set('bin/typo3cms', './vendor/bin/typo3cms');


### PR DESCRIPTION
I was wondering, why this was not set before. 
This is the default for all projects, right?