### PR TITLE
feat: use rsync option within db_sync_tool as default

### DIFF
--- a/deployer/feature/task/feature_sync.php
+++ b/deployer/feature/task/feature_sync.php
@@ -20,7 +20,7 @@ task('feature:sync', function () {
     if (get('db_sync_tool') !== false) {
         if (commandExistLocally("{{db_sync_tool}}")) {
             info('Synching database');
-            runLocally("{{db_sync_tool}} -f {{feature_sync_config}} --target-path {{feature_sync_target_path}} -y $optionalVerbose");
+            runLocally("{{db_sync_tool}} -f {{feature_sync_config}} --target-path {{feature_sync_target_path}} --use-rsync -y $optionalVerbose");
             $synced = true;
         } else {
             debug("Skipping database sync, command \”{{db_sync_tool}}\” not available");

--- a/deployer/sync/task/database_backup.php
+++ b/deployer/sync/task/database_backup.php
@@ -8,7 +8,7 @@ task('database:backup', function () {
 
     if (commandExistLocally("{{db_sync_tool}}")) {
         info('Generating a database backup');
-        runLocally("{{db_sync_tool}} -f {{sync_database_backup_config}} -y $optionalVerbose");
+        runLocally("{{db_sync_tool}} -f {{sync_database_backup_config}} --use-rsync -y $optionalVerbose");
     } else {
         debug("Skipping database sync, {{db_sync_tool}} not available");
     }


### PR DESCRIPTION
Use rsync instead of sftp as default sync of database dumps to fulfill the new security standards. 