### PR TITLE
fix: duplicate lines in composer_update

### DIFF
--- a/deployer/dev/task/composer_update.php
+++ b/deployer/dev/task/composer_update.php
@@ -27,6 +27,9 @@ function composerUpdate(string $mode = "app"): void {
         add('dev_empty_tasks', ["dev:release:composer_update_$mode"]);
         return;
     }
+
+    $matches[1] = array_unique($matches[1]);
+
     foreach ($matches[1] as $index => $package) {
         $message .= " - $package (" . $matches[2][$index] . ")\n";
     }


### PR DESCRIPTION
Under some circumstances, the output of composer update may have lines matched by the regexp multiple times